### PR TITLE
Changed the vespa podLabels to work properly

### DIFF
--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -298,7 +298,7 @@ vespa:
   podAnnotations: {}
   podLabels: 
     app: vespa
-    app.kubernetes.io/instance: danswer-stack-kn
+    app.kubernetes.io/instance: danswer
     app.kubernetes.io/name: vespa
   enabled: true
 


### PR DESCRIPTION
Vespa is not working because this configuration

As you can see in this Issue https://github.com/unoplat/vespa-helm-charts/issues/20

You have to use this podLabels to be accord with the other configuration.

vespa:
  podLabels:
    app: vespa
    app.kubernetes.io/instance: danswer <-------------